### PR TITLE
Change synthesis target

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -863,7 +863,7 @@ sources:
            - hw/vendor/common_pads/src/pad_alsaqr.sv
            - hw/tb/testbench_asynch_astral.sv
 
-      - target: synthesis
+      - target: ot_synthesis
         files:
            - target/gf22/sourcecode/tc_sram.sv
            - target/gf22/sourcecode/tc_clk.sv


### PR DESCRIPTION
The target `synthesis` is used also in Astral to implement the top level. This creates conflicts because Design Compiler looks for `/path/to/opentitan/target/gf22/sourcecode/tc_clk/sram.sv` and fails because we did not initializa the opentitan implementation repository. Proposing a specific target to prevent this from happening.
NB1: this is a patch, IMHO this should be handled in the tech folder (for example with a dedicated compile script for technological cells).
NB2: this PR depends on the [security island backend](https://gitlab.chips.it/digitalresearchline/referencedesignflow/gf22/security_island/-/merge_requests/3) one