### PR TITLE
Avoid SSH clone for gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "sw/tests/pulp-runtime"]
 	path = sw/tests/pulp-runtime
-	url = git@github.com:FondazioneChipsIT/pulp-runtime.git
+	url = https://github.com/FondazioneChipsIT/pulp-runtime.git
 	branch = add_ot_target
 [submodule "sw/tests/regression_tests"]
 	path = sw/tests/regression_tests
-	url = git@github.com:FondazioneChipsIT/regression_tests.git
+	url = https://github.com/FondazioneChipsIT/regression_tests.git
 	branch = gl/ot_cluster


### PR DESCRIPTION
This way we do not force external people to register an SSH key on github to recursively clone the submodules.