### PR TITLE
Fixes and advancement for SCARV's Security Island

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -1,7 +1,7 @@
 overrides:
   riscv:                { git: "https://github.com/AlSaqr-platform/riscv_nn.git", rev: "e437cff049443dac25a2c3a35e9890a577f9493a" } # branch: alsaqr-2.0
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: =0.2.13 }
-  fpnew:                { git: "https://github.com/pulp-platform/cvfpu.git", rev: pulp-v0.1.3 }
+  fpnew:                { git: "https://github.com/FondazioneChipsIT/cvfpu.git", rev: 49b1cb4d50893a9d23f8329d857527ebe5bc8529 } # branch: yt/pulp-merge-v2
   hwpe-ctrl:            { git: "https://github.com/pulp-platform/hwpe-ctrl.git", rev: 3690a3c }
   hwpe-stream:          { git: "https://github.com/pulp-platform/hwpe-stream.git", rev: c1e25094bf9f2fee754611ef7491b7a1144e11b9 }
   axi:                  { git: "https://github.com/pulp-platform/axi.git", version: =0.39.8 }

--- a/Bender.lock
+++ b/Bender.lock
@@ -123,10 +123,10 @@ packages:
     - fpnew
     - tech_cells_generic
   fpnew:
-    revision: a8e0cba6dd50f357ece73c2c955d96efc3c6c315
+    revision: 49b1cb4d50893a9d23f8329d857527ebe5bc8529
     version: null
     source:
-      Git: https://github.com/pulp-platform/cvfpu.git
+      Git: https://github.com/FondazioneChipsIT/cvfpu.git
     dependencies:
     - common_cells
     - fpu_div_sqrt_mvp

--- a/Bender.yml
+++ b/Bender.yml
@@ -871,3 +871,4 @@ sources:
         files:
            - target/gf22/sourcecode/tc_sram.sv
            - target/gf22/sourcecode/tc_clk.sv
+           - target/gf22/sourcecode/sync.sv

--- a/hw/tb/testbench_asynch_astral.sv
+++ b/hw/tb/testbench_asynch_astral.sv
@@ -428,7 +428,7 @@ axi_sim_mem_intf #(
 // -----------------------------------------------------------------------------------
 // DUT
 // -----------------------------------------------------------------------------------
-`ifdef TECH_SIM
+`ifdef SECD_NETLIST
    security_island dut (
 `else
    // we are using hartid = 4 so that we can use the same debug rom as in scarv

--- a/hw/top_earlgrey/top/secure_subsystem_asynch_synth_wrap_astral.sv
+++ b/hw/top_earlgrey/top/secure_subsystem_asynch_synth_wrap_astral.sv
@@ -349,7 +349,7 @@ module security_island
      .STAGES     ( SyncStages ),
      .ResetValue ( 1'b0       )
    ) i_fetch_en_sync (
-     .clk_i,
+     .clk_i    ( s_clk_ot      ),
      .rst_ni   ( pwr_on_rst_ni ),
      .serial_i ( fetch_en_i    ),
      .serial_o ( fetch_en_sync )
@@ -359,7 +359,7 @@ module security_island
      .STAGES     ( SyncStages ),
      .ResetValue ( 1'b0       )
    ) i_irq_sync (
-     .clk_i,
+     .clk_i    ( s_clk_ot      ),
      .rst_ni   ( pwr_on_rst_ni ),
      .serial_i ( irq_ibex_i    ),
      .serial_o ( irq_ibex_sync )
@@ -369,7 +369,7 @@ module security_island
      .STAGES     ( SyncStages ),
      .ResetValue ( 1'b1       )
    ) i_isolate_sync_tlul2axi (
-     .clk_i,
+     .clk_i    ( s_clk_ot         ),
      .rst_ni   ( pwr_on_rst_ni    ),
      .serial_i ( axi_isolate_i    ),
      .serial_o ( axi_isolate_sync )
@@ -394,7 +394,7 @@ module security_island
       .axi_req_t  ( axi_ext_req_t     ),
       .axi_resp_t ( axi_ext_resp_t    )
    ) i_cdc_out_tlul2axi (
-      .src_clk_i                   ( clk_i                   ),
+      .src_clk_i                   ( s_clk_ot                ),
       .src_rst_ni                  ( pwr_on_rst_ni           ),
       .async_data_master_aw_data_o ( async_axi_ext_aw_data_o ),
       .async_data_master_aw_wptr_o ( async_axi_ext_aw_wptr_o ),
@@ -426,7 +426,7 @@ module security_island
      .axi_req_t            ( axi_ext_req_t  ),
      .axi_resp_t           ( axi_ext_resp_t )
    ) i_axi_out_isolate_tlul2axi (
-     .clk_i                ( clk_i                  ),
+     .clk_i                ( s_clk_ot               ),
      .rst_ni               ( rst_ni                 ),
      .slv_req_i            ( axi_ext_serialized_req ),
      .slv_resp_o           ( axi_ext_serialized_rsp ),
@@ -449,7 +449,7 @@ module security_island
     .mst_req_t              ( axi_ext_req_t  ),
     .mst_resp_t             ( axi_ext_resp_t )
    ) ot_id_remap (
-    .clk_i      ( clk_i                  ),
+    .clk_i      ( s_clk_ot               ),
     .rst_ni     ( rst_ni                 ),
     .slv_req_i  ( axi_ext_mst_req        ),
     .slv_resp_o ( axi_ext_mst_rsp        ),
@@ -460,9 +460,9 @@ module security_island
    rng #(
       .EntropyStreams ( 4 )
    ) u_rng (
-      .clk_i          ( clk_i                 ),
+      .clk_i          ( s_clk_ot              ),
       .rst_ni         ( s_rst_n               ),
-      .clk_ast_rng_i  ( clk_i                 ),
+      .clk_ast_rng_i  ( s_clk_ot              ),
       .rst_ast_rng_ni ( s_rst_n               ),
       .rng_en_i       ( es_rng_req.rng_enable ),
       .rng_fips_i     ( es_rng_fips           ),
@@ -550,7 +550,7 @@ module security_island
     .mst_resp_t   ( axi_out_resp_t    ),
     .rule_t       ( xbar_rule_t       )
   ) i_axi_xbar (
-    .clk_i                  ( clk_i       ),
+    .clk_i                  ( s_clk_ot    ),
     .rst_ni                 ( rst_ni      ),
     .test_i                 ( '0          ),
     .slv_ports_req_i        ( axi_slv_req ),
@@ -585,7 +585,7 @@ module security_island
       .axi_req_t  ( axi_out_req_t     ),
       .axi_resp_t ( axi_out_resp_t    )
   ) i_axi_cut (
-      .clk_i      ( clk_i              ),
+      .clk_i      ( s_clk_ot           ),
       .rst_ni     ( rst_ni             ),
       .slv_req_i  ( axi_l2_mst_req     ),
       .slv_resp_o ( axi_l2_mst_rsp     ),
@@ -608,7 +608,7 @@ module security_island
       .MemAddrWidth  ( $clog2(L2BankWords)),
       .MemDataWidth  ( MemDataWidth       )
   ) axi_to_mem_instance (
-      .clk_i       ( clk_i               ),
+      .clk_i       ( s_clk_ot            ),
       .rst_ni      ( rst_ni              ),
       .test_i      ( '0                  ),
       .axi_req_i   ( axi_l2_mst_req_del  ),
@@ -636,7 +636,7 @@ module security_island
       .PrintSimCfg ( 0            ), // Print configuration
       .Latency     ( 1            )  // Latency when the read data is available
     ) i_bank (
-      .clk_i   ( clk_i                  ), // Clock
+      .clk_i   ( s_clk_ot               ), // Clock
       .rst_ni  ( rst_ni                 ), // Asynchronous reset active low
       .req_i   ( l2_mem_slave_req   [i] ), // request
       .we_i    ( l2_mem_slave_we    [i] ), // write enable
@@ -715,7 +715,7 @@ module security_island
      .AXI_DATA_WIDTH (AxiDataWidth),
      .AXI_USER_WIDTH (AxiUserWidth)
    ) u_cluster_slave_id_serializer (
-     .clk_i (clk_i),
+     .clk_i (s_clk_ot),
      .rst_ni (pwr_on_rst_ni),
      .slv (soc_to_cluster_axi_bus),
      .mst (serialized_soc_to_cluster_axi_bus)
@@ -733,7 +733,7 @@ module security_island
      .LOG_DEPTH      ( LogDepth      ),
      .SYNC_STAGES    ( SyncStages    )
    ) soc_to_cluster_src_cdc_fifo_i (
-       .src_clk_i  ( clk_i                             ),
+       .src_clk_i  ( s_clk_ot                          ),
        .src_rst_ni ( pwr_on_rst_ni                     ),
        .src        ( serialized_soc_to_cluster_axi_bus ),
        .dst        ( async_soc_to_cluster_axi_bus      )
@@ -747,7 +747,7 @@ module security_island
      .LOG_DEPTH      ( LogDepth     ),
      .SYNC_STAGES    ( SyncStages   )
    ) cluster_to_soc_dst_cdc_fifo_i (
-       .dst_clk_i  ( clk_i                        ),
+       .dst_clk_i  ( s_clk_ot                     ),
        .dst_rst_ni ( pwr_on_rst_ni                ),
        .src        ( async_cluster_to_soc_axi_bus ),
        .dst        ( cluster_to_soc_axi_bus       )
@@ -765,7 +765,7 @@ module security_island
     .reg_req_t    ( secd_bus_req_t ),
     .reg_rsp_t    ( secd_bus_rsp_t )
   ) i_axi2reg (
-    .clk_i,
+    .clk_i      ( s_clk_ot        ),
     .rst_ni,
     .axi_req_i  ( axi_reg_mst_req ),
     .axi_rsp_o  ( axi_reg_mst_rsp ),
@@ -811,7 +811,7 @@ module security_island
     .req_t    ( secd_bus_req_t ),
     .rsp_t    ( secd_bus_rsp_t )
   ) i_reg_demux (
-    .clk_i,
+    .clk_i        ( s_clk_ot           ),
     .rst_ni,
     .in_select_i  ( s_secd_reg_select  ),
     .in_req_i     ( s_secd_reg_req     ),
@@ -838,7 +838,7 @@ module security_island
     .reg_req_t ( secd_bus_req_t ),
     .reg_rsp_t ( secd_bus_rsp_t )
   ) i_secd_reg_top (
-    .clk_i,
+    .clk_i     ( s_clk_ot         ),
     .rst_ni,
     .reg_req_i ( s_secd_reg_out_req[RegAddrIdx] ), // 1
     .reg_rsp_o ( s_secd_reg_out_rsp[RegAddrIdx] ), // 1
@@ -856,7 +856,7 @@ module security_island
     .reg_rsp_t( secd_bus_rsp_t ),
     .NumMbox  ( 1 )
   ) i_mailbox_unit (
-    .clk_i,
+    .clk_i     ( s_clk_ot         ),
     .rst_ni,
     .reg_req_i ( s_secd_reg_out_req[MboxAddrIdx] ), // 2
     .reg_rsp_o ( s_secd_reg_out_rsp[MboxAddrIdx] ), // 2

--- a/hw/top_earlgrey/top/secure_subsystem_asynch_synth_wrap_astral.sv
+++ b/hw/top_earlgrey/top/secure_subsystem_asynch_synth_wrap_astral.sv
@@ -29,7 +29,7 @@ module security_island
    import top_earlgrey_pkg::*;
    import security_island_reg_pkg::*;
 #(
-   parameter int unsigned HartIdOffs = 0,
+   parameter int unsigned HartIdOffs = 4,
    // Shared AXI parameters
    parameter int unsigned AxiAddrWidth = SynthAxiAddrWidth,
    parameter int unsigned AxiDataWidth = SynthAxiDataWidth,

--- a/hw/top_earlgrey/top/secure_subsystem_asynch_synth_wrap_astral.sv
+++ b/hw/top_earlgrey/top/secure_subsystem_asynch_synth_wrap_astral.sv
@@ -273,6 +273,7 @@ module security_island
 
    logic fetch_en_sync;
    logic irq_ibex_sync;
+   logic axi_isolate_sync;
 
    wire [1:0] flash_testmode_tieoff;
    wire otp_ext_tieoff, flash_testvolt_tieoff;

--- a/hw/top_earlgrey/top/secure_subsystem_synth_astral_pkg.sv
+++ b/hw/top_earlgrey/top/secure_subsystem_synth_astral_pkg.sv
@@ -14,9 +14,9 @@ package secure_subsystem_synth_astral_pkg;
 
   localparam SynthAxiAddrWidth    = 48;
   localparam SynthAxiDataWidth    = 64;
-  localparam SynthAxiUserWidth    = 1;
+  localparam SynthAxiUserWidth    = 10;
   // External AXI master port ID Width
-  localparam SynthAxiExtIdWidth   = 4;
+  localparam SynthAxiExtIdWidth   = 2;
   // Security Island internal crossbar AXI ID Widths
   // These are from the AXI XBAR perspective, so:
   // - "out" refers to XBAR master ports (slave devices -> external, PULP cluster slave)
@@ -39,7 +39,7 @@ package secure_subsystem_synth_astral_pkg;
   `AXI_TYPEDEF_ALL(synth_axi_in, synth_axi_addr_t, synth_axi_in_id_t, synth_axi_data_t, synth_axi_strb_t, synth_axi_user_t)
 
   localparam SynthLogDepth = 3;
-  localparam SynthCdcSyncStages = 2;
+  localparam SynthCdcSyncStages = 3;
 
   localparam AxiMaxOutTrans = 2;
 

--- a/opentitan.mk
+++ b/opentitan.mk
@@ -198,10 +198,9 @@ init: update generate_idma_rtl $(OT_ROOT)/hw/tb/vips scripts/compile_opentitan.t
 # Technology #
 ##############
 tech-repo := git@gitlab.chips.it:digitalresearchline/referencedesignflow/gf22/security_island.git
-tech-commit := 03449ed7405ae4e6234c6d0b1993c0a5e9124984
+tech-commit := 83374e87e95426849791db289951267558c93089 # scarv-devel
 
 tech-clone:
-	rm -rf target/gf22
 	git clone $(tech-repo) target/gf22
 
 tech-init: tech-clone


### PR DESCRIPTION
This PR mainly:

- Fix clock propagation from internal clock dividers
- Align default parameters to reflect SCARV integration
- Bump tech-commit

As a sanity check, during review, please verify that the repository can be correctly set up