### PR TITLE
[SW] Add mbox_wu_cluster test

### DIFF
--- a/opentitan-cluster.yaml
+++ b/opentitan-cluster.yaml
@@ -53,3 +53,6 @@ opentitan-cluster:
    wu_ibex:
       path: .
       command: make sim_rtl SRAM=sw/tests/scarv/mbox_ext_irq/bazel-out/mbox_ext_irq.elf cl-test=wu_ibex
+   wu_ibex:
+      path: .
+      command: make sim_rtl SRAM=sw/tests/scarv/mbox_wu_cluster/bazel-out/mbox_wu_cluster.elf cl-test=mbox_wfe_cluster

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -1,8 +1,9 @@
 SCARV_TESTS := \
 	cluster_offload \
-	mbox_host \
+	idma_test \
 	mbox_ext_irq \
-	idma_test
+	mbox_host \
+	mbox_wu_cluster
 
 PULP_SW_DIR  := $(PULP_REGR_DIR)
 PULP_TEST_DIRS := $(filter-out %deeploy %neureka, $(wildcard $(PULP_SW_DIR)/opentitan-cluster/*))

--- a/sw/tests/scarv/mbox_wu_cluster/BUILD
+++ b/sw/tests/scarv/mbox_wu_cluster/BUILD
@@ -1,0 +1,21 @@
+# Copyright 2026 ETH Zurich, University of Bologna and Fondazione Chips-IT.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:opentitan.bzl", "opentitan_ram_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+opentitan_ram_binary(
+    name = "mbox_wu_cluster",
+    srcs = [
+        "mbox_wu_cluster.c",
+    ],
+    archive_symbol_prefix = "mbox_wu_cluster",
+    testonly = True,
+    deps = [
+        "//sw/tests/common:common",
+        "//sw/tests/common:linker",
+        "//sw/tests/common:crt",
+    ],
+)

--- a/sw/tests/scarv/mbox_wu_cluster/BUILD
+++ b/sw/tests/scarv/mbox_wu_cluster/BUILD
@@ -8,9 +8,8 @@ package(default_visibility = ["//visibility:public"])
 
 opentitan_ram_binary(
     name = "mbox_wu_cluster",
-    srcs = [
-        "mbox_wu_cluster.c",
-    ],
+    srcs = ["mbox_wu_cluster.c"],
+    hdrs = ["mbox_wu_cluster.h"],
     archive_symbol_prefix = "mbox_wu_cluster",
     testonly = True,
     deps = [

--- a/sw/tests/scarv/mbox_wu_cluster/Makefile
+++ b/sw/tests/scarv/mbox_wu_cluster/Makefile
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generate a baremetal application
+
+# Name of the program $(PROGRAM).c will be added as a source file
+PROGRAM = mbox_wu_cluster
+# STANDALONE MODE
+ifneq ($(NO_STANDALONE),)
+PROGRAM_CFLAGS += -DNO_STANDALONE
+PROGRAM_CFLAGS += -Wno-int-conversion -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-implicit-int
+endif
+PROGRAM_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+# Any extra source files to include in the build. Use the upper case .S
+# extension for assembly files
+
+utils_dir = $(PROGRAM_DIR)/inc/
+directories = drivers/inc drivers/src string_lib/inc string_lib/src
+EXTRA_SRCS = $(foreach d, $(directories), -I$(utils_dir)$d)
+
+include ${PROGRAM_DIR}/../../common/common.mk

--- a/sw/tests/scarv/mbox_wu_cluster/mbox_wu_cluster.c
+++ b/sw/tests/scarv/mbox_wu_cluster/mbox_wu_cluster.c
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// mbox_wfe_host - Ibex side of the reverse-mailbox WFE test
+//
+// This test is the counterpart of
+//   sw/tests/regression_tests/opentitan-cluster/mbox_wfe_test/test.c
+//
+// Scenario
+// ========
+// The cluster side configures EU event bit 22 (= mbox_irq_i) and executes a
+// p.elw (Wait-For-Event) instruction.  This ibex program:
+//
+//   1. Enables the EDN entropy source (required for the SoC).
+//   2. Configures and starts the PULP cluster.
+//   3. Waits until the cluster has enabled the mailbox RCV interrupt path by
+//      polling the IRQ_RCV_EN register - this is the cluster's "ready" signal.
+//   4. Writes test data into the two mailbox letter registers.
+//   5. Asserts IRQ_RCV_SET = 1 -> the mailbox asserts mbox_irq_i ->
+//      EU bit 22 fires -> cluster core 0 wakes from WFE.
+//   6. Waits for the cluster End-Of-Computation (EOC) flag.
+//   7. Disables cluster fetch and exits.
+//
+// No PLIC-based interrupt is needed on the ibex side for this test; ibex is
+// the sender/trigger and the cluster is the recipient.
+//
+// Mailbox register map (ibex side, from sw/tests/common/mailboxes.h)
+// ===================================================================
+//   MAILBOX_BASE_ADDR              = 0xBF010000
+//   + ARCHI_MAILBOX_IRQ_RCV_STAT   = 0x40  -> 0xBF010040  (read: RCV pending)
+//   + ARCHI_MAILBOX_IRQ_RCV_SET    = 0x44  -> 0xBF010044  (write 1: trigger)
+//   + ARCHI_MAILBOX_IRQ_RCV_CLR    = 0x48  -> 0xBF010048  (write 1: clear)
+//   + ARCHI_MAILBOX_IRQ_RCV_EN     = 0x4C  -> 0xBF01004C  (poll: cluster rdy)
+//   + ARCHI_MAILBOX_LETTER0        = 0x80  -> 0xBF010080
+//   + ARCHI_MAILBOX_LETTER1        = 0x84  -> 0xBF010084
+//
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "utils.h"
+#include "mailboxes.h"
+
+/* -- Cluster control registers --------------------------------------------- */
+/* Entry point in L2 where every cluster PE starts execution.                 */
+#define CLUSTER_ENTRY_ADDR      0xA0008080
+/* Per-core boot address registers (8 cores, 4-byte stride).                  */
+#define CLUSTER_BOOT_ADDR_REG   0xB0200040
+/* Security-island peripheral registers (mapped in ibex's address space).     */
+#define CLUSTER_FETCH_EN_REG    0xBF000000   /* write 1 to start cluster      */
+#define CLUSTER_EOC_REG         0xBF000004   /* read: non-zero = completed    */
+#define CLUSTER_CLK_EN_REG      0xBF000008
+#define CLUSTER_CLK_DIV_REG     0xBF00000C
+#define OT_CLK_DIV_REG          0xBF000010
+/* EDN entropy source enable.                                                 */
+#define EDN_EN_ADDR_REG         0xC1170014
+/* Number of compute cores in the PULP cluster.                               */
+#define CLUSTER_NUM_CORES       8
+
+/* -- Test data written into the mailbox ------------------------------------ */
+#define TEST_LETTER0  0xBAADC0DE
+#define TEST_LETTER1  0xDEADBEEF
+
+int main(void)
+{
+    volatile int *p_reg;
+    volatile int *fetch_en    = (int *)CLUSTER_FETCH_EN_REG;
+    volatile int *eoc         = (int *)CLUSTER_EOC_REG;
+    volatile int *edn_enable  = (int *)EDN_EN_ADDR_REG;
+
+    /* -- Step 1: Enable EDN entropy source --------------------------------- */
+    *edn_enable = 0x9996;
+
+    /* -- Step 2: Configure and start the cluster --------------------------- */
+    for (int i = 0; i < CLUSTER_NUM_CORES; i++) {
+        volatile int *boot_addr = (int *)(CLUSTER_BOOT_ADDR_REG + 0x4 * i);
+        *boot_addr = CLUSTER_ENTRY_ADDR;
+    }
+
+    /* Release all cluster cores.  They will boot, run cluster_core_init()
+     * then enter main() where core 0 enables IRQ_RCV_EN and sleeps in WFE. */
+    *fetch_en = 0x1;
+
+    /* -- Step 3: Poll IRQ_RCV_EN - wait for cluster "ready" signal --------- */
+    /*
+     * Spinning here ensures we do not trigger the RCV interrupt before the
+     * cluster EU mask is set and the core is actually sleeping.
+     */
+    p_reg = (int *)(MAILBOX_BASE_ADDR + ARCHI_MAILBOX_IRQ_RCV_EN_OFFSET);
+    while (*p_reg == 0) {
+        /* busy-wait: cluster not ready yet */
+    }
+
+    /* -- Step 4: Write test data into the mailbox letters ------------------ */
+    p_reg  = (int *)(MAILBOX_BASE_ADDR + ARCHI_MAILBOX_LETTER0_OFFSET);
+    *p_reg = TEST_LETTER0;
+
+    p_reg  = (int *)(MAILBOX_BASE_ADDR + ARCHI_MAILBOX_LETTER1_OFFSET);
+    *p_reg = TEST_LETTER1;
+
+    /* -- Step 5: Assert IRQ_RCV_SET to wake the cluster -------------------- */
+    /*
+     * Writing 1 to IRQ_RCV_SET while IRQ_RCV_EN=1 causes the mailbox to
+     * assert rcv_irq_o = s_mbox2cl_irq = mbox_irq_i on the cluster.
+     * The cluster_peripherals assigns this to s_cluster_events[I][0] which
+     * cluster_event_map routes to EU event bit 22 for every PE.
+     * Core 0 has bit 22 in its EU event mask -> it wakes from p.elw.
+     */
+    p_reg  = (int *)(MAILBOX_BASE_ADDR + ARCHI_MAILBOX_IRQ_RCV_SET_OFFSET);
+    *p_reg = 0x1;
+
+    /* -- Step 6: Wait for cluster End-Of-Computation ----------------------- */
+    while (!(*eoc)) {
+        /* busy-wait */
+    }
+
+    /* -- Step 7: Disable cluster and exit ---------------------------------- */
+    *fetch_en = 0x0;
+
+    return 0;
+}

--- a/sw/tests/scarv/mbox_wu_cluster/mbox_wu_cluster.c
+++ b/sw/tests/scarv/mbox_wu_cluster/mbox_wu_cluster.c
@@ -1,4 +1,4 @@
-// Copyright lowRISC contributors.
+// Copyright 2026 ETH Zurich, University of Bologna and Fondazione Chips-IT.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/sw/tests/scarv/mbox_wu_cluster/mbox_wu_cluster.h
+++ b/sw/tests/scarv/mbox_wu_cluster/mbox_wu_cluster.h
@@ -1,0 +1,8 @@
+// Copyright 2026 ETH Zurich, University of Bologna and Fondazione Chips-IT.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MBOX_WU_TEST_H_
+#define MBOX_WU_TEST_H_
+
+#endif  // MBOX_WU_TEST_H_


### PR DESCRIPTION
This PR adds the `mbox_wu_cluster test` to SCARV test list. This code tests the ability of Ibex to trigger an event for the cluster.
It has to be used with the `mbox_wfe_cluster` cluster test.